### PR TITLE
Fix groups; admin does not exist on EL

### DIFF
--- a/manifests/archive.pp
+++ b/manifests/archive.pp
@@ -51,8 +51,8 @@ define backups::archive(
 
   concat {
     "/etc/backup/models/${name}.rb":
-      owner => root,
-      group => admin,
+      owner => 'root',
+      group => 'root',
       mode  => 0440;
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,8 +62,8 @@ class backups (
 
   file { '/etc/backup':
     ensure  => directory,
-    owner   => root,
-    group   => admin,
+    owner   => 'root',
+    group   => 'root',
     mode    => '0550',
     purge   => true,
     force   => true,
@@ -72,22 +72,22 @@ class backups (
 
   file { '/etc/backup/models':
     ensure  => directory,
-    owner   => root,
-    group   => admin,
+    owner   => 'root',
+    group   => 'root',
     mode    => '0550',
     require => File['/etc/backup'],
   }
 
   file { '/var/log/backup':
     ensure  => directory,
-    owner   => root,
-    group   => admin,
+    owner   => 'root',
+    group   => 'root',
     mode    => '0555',
   }
 
   file { '/etc/backup/config.rb':
-    owner   => root,
-    group   => admin,
+    owner   => 'root',
+    group   => 'root',
     mode    => '0440',
     content => template('backups/config.rb'),
   }

--- a/manifests/riak.pp
+++ b/manifests/riak.pp
@@ -64,8 +64,8 @@ define backups::riak (
 
   concat {
     "/etc/backup/models/${name}.rb":
-      owner => root,
-      group => admin,
+      owner => 'root',
+      group => 'root',
       mode  => 0440;
   }
 

--- a/spec/classes/backups_init_spec.rb
+++ b/spec/classes/backups_init_spec.rb
@@ -13,13 +13,13 @@ describe 'backups', :type => :class do
       it { should contain_file(directory).with(
         'ensure'  => 'directory',
         'owner'   => 'root',
-        'group'   => 'admin'
+        'group'   => 'root'
       ) }
     end
 
     it { should create_file('/etc/backup/config.rb').with(
       'owner'   => 'root',
-      'group'   => 'admin',
+      'group'   => 'root',
       'mode'    => '0440'
     ) }
 


### PR DESCRIPTION
The module references a group named 'admin' but this group doesn't exist on many Linux distros.
