### PR TITLE
Additional email options

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,18 @@ Integer.  Port on `relayhost` emails should be sent to
 
 Default: 25
 
+##### `mail_encryption`
+
+String. Encryption to be used.
+
+Default: not defined (backup currently defaults to `:starttls`.
+
+##### `mail_domain`
+
+String. Your host name for the HELO command.
+
+Default: none.
+
 ##### `enable_hc`
 
 Boolean.  Whether backup job noticies should be sent to HipChat

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -230,8 +230,6 @@ define backup::job (
 
     if !$email_to {
       fail("[Backup::Job::${name}]: A destination email address is required for email notifications")
-    } else {
-      validate_re($email_to, '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$', "[Backup::Job::${name}]: ${email_to} is not a valid email address")
     }
 
     if $relay_port and !is_integer($relay_port) {

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -68,6 +68,8 @@ define backup::job (
   $email_to         = undef,
   $relay_host       = 'localhost',
   $relay_port       = '25',
+  $mail_domain      = undef,
+  $mail_encryption  = undef,
   # Hipchat
   $enable_hc        = false,
   $hc_success       = false,

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -415,6 +415,8 @@ define backup::job (
     # - $email_to
     # - $relay_host
     # - $relay_port
+    # - $mail_domain
+    # - $mail_encryption
     concat::fragment { "${_name}_email":
       target  => "/etc/backup/models/${_name}.rb",
       content => template('backup/job/email.erb'),

--- a/templates/job/email.erb
+++ b/templates/job/email.erb
@@ -13,4 +13,10 @@
 <% if @relay_host -%>
     mail.port                 = <%= @relay_port %>
 <% end -%>
+<% if @mail_domain -%>
+    mail.domain               = <%= @mail_domain %>
+<% end -%>
+<% if @mail_encryption -%>
+    mail.encryption           = <%= @mail_encryption %>
+<% end -%>
   end

--- a/templates/job/email.erb
+++ b/templates/job/email.erb
@@ -14,7 +14,7 @@
     mail.port                 = <%= @relay_port %>
 <% end -%>
 <% if @mail_domain -%>
-    mail.domain               = <%= @mail_domain %>
+    mail.domain               = "<%= @mail_domain %>"
 <% end -%>
 <% if @mail_encryption -%>
     mail.encryption           = <%= @mail_encryption %>


### PR DESCRIPTION
1. Added 2 options for email: encryption and domain. Both were needed for my set up to work. 
2. Removed the validation of the to_email because the way it was, you can't send email to multiple recipients. Without it, you have set the string to `'joe@example.org,bob@example.org'` and it will send the email to both. I think it would be nicer if it was an array of string as you could then do validation but I couldn't figure out how to loop through an array in Puppet and I ran out of time for this.