### PR TITLE
Support S3 reduced redundancy

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -42,10 +42,12 @@ define backup::job (
   $split_into        = $::backup::split_into,
   $path              = $::backup::path,
   # S3
-  $aws_access_key    = $::backup::aws_access_key,
-  $aws_secret_key    = $::backup::aws_secret_key,
-  $bucket            = $::backup::bucket,
-  $aws_region        = $::backup::aws_region,
+  $aws_access_key      = $::backup::aws_access_key,
+  $aws_secret_key      = $::backup::aws_secret_key,
+  $bucket              = $::backup::bucket,
+  $aws_region          = $::backup::aws_region,
+  $reduced_redundancy  = $::backup::reduced_redundancy,
+
   # Remote storage common
   $storage_username  = $::backup::storage_username,
   $storage_password  = $::backup::storage_password,
@@ -183,6 +185,8 @@ define backup::job (
 
   # S3
   if $storage_type == 's3' {
+    validate_bool($reduced_redundancy)
+
     if !$aws_access_key or !is_string($aws_access_key) {
       fail("[Backup::Job::${name}]: Parameter aws_access_key is required for S3 storage")
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -45,6 +45,7 @@ class backup::params {
   $aws_secret_key       = undef
   $bucket               = undef
   $aws_region           = undef
+  $reduced_redundancy   = false
   # Remote storage common
   $storage_username     = undef
   $storage_password     = undef

--- a/spec/defines/backup_job_spec.rb
+++ b/spec/defines/backup_job_spec.rb
@@ -241,6 +241,19 @@ describe 'backup::job', :types=> :define do
         } }
         it { expect { is_expected.to compile }.to raise_error(/foo is an invalid region/) }
       end
+
+      context 'bad reduced_redundancy s3 setting' do
+        let(:params) { {
+          :types          => 'archive',
+          :add            => '/here',
+          :storage_type   => 's3',
+          :aws_access_key => 'foo',
+          :aws_secret_key => 'foo',
+          :reduced_redundancy => 'foo'
+        } }
+        it { expect { is_expected.to compile }.to raise_error(/boolean/) }
+      end
+
     end #s3
 
     context 'ftp storage' do
@@ -883,6 +896,7 @@ describe 'backup::job', :types=> :define do
         it { should contain_concat__fragment('job1_s3').with(:content => /s3\.bucket\s+=\s+"bucket"/) }
         it { should_not contain_concat__fragment('job1_s3').with(:content => /s3\.region/) }
         it { should_not contain_concat__fragment('job1_s3').with(:content => /s3\.keep/) }
+        it { should_not contain_concat__fragment('job1_s3').with(:content => /s3\.storage_class/) }
       end
 
       context 'all params' do
@@ -894,7 +908,8 @@ describe 'backup::job', :types=> :define do
           :aws_secret_key   => 'bar',
           :bucket           => 'bucket',
           :aws_region       => 'us-east-1',
-          :keep             => 3
+          :keep             => 3,
+          :reduced_redundancy => true
         } }
         it { should contain_concat__fragment('job1_s3').with(:content => /s3\.access_key_id\s+=\s+"foo"/) }
         it { should contain_concat__fragment('job1_s3').with(:content => /s3\.secret_access_key\s+=\s+"bar"/) }
@@ -902,6 +917,7 @@ describe 'backup::job', :types=> :define do
         it { should contain_concat__fragment('job1_s3').with(:content => /s3\.bucket\s+=\s+"bucket"/) }
         it { should contain_concat__fragment('job1_s3').with(:content => /s3\.region\s+=\s+"us-east-1"/) }
         it { should contain_concat__fragment('job1_s3').with(:content => /s3\.keep\s+=\s+3/) }
+        it { should contain_concat__fragment('job1_s3').with(:content => /s3\.storage_class\s+=\s+:reduced_redundancy/) }
       end
     end #s3
 

--- a/templates/job/s3.erb
+++ b/templates/job/s3.erb
@@ -12,4 +12,7 @@
 <% if @keep -%>
     s3.keep              = <%= @keep -%>
 <% end -%>
+<% if @reduced_redundancy -%>
+    s3.storage_class     = :reduced_redundancy
+<% end -%>
   end


### PR DESCRIPTION
AWS supports two storage classes, reduced redundancy being the cheaper and suitable for backups.

I opted for a bool flag to avoid typos or confusion specifying the storage class name explicitly.
