### PR TITLE
Allow setting custom bin path for backup gem

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -13,6 +13,7 @@ define backup::job (
   $ensure            = 'present',
   $utilities         = undef,
   $tmp_path          = '~/Backup/.tmp',
+  $gem_bin_path      = '/usr/local/bin',
   $before_job        = undef,
   $after_job         = undef,
 
@@ -515,7 +516,7 @@ define backup::job (
 
   cron { "${name}-backup":
     ensure   => $ensure,
-    command  => "/usr/local/bin/backup perform --trigger ${_name} --config-file '/etc/backup/config.rb' --tmp-path ${tmp_path}",
+    command  => "${gem_bin_path}/backup perform --trigger ${_name} --config-file '/etc/backup/config.rb' --tmp-path ${tmp_path}",
     minute   => $minute,
     hour     => $hour,
     monthday => $monthday,

--- a/spec/defines/backup_job_spec.rb
+++ b/spec/defines/backup_job_spec.rb
@@ -1056,6 +1056,17 @@ describe 'backup::job', :types=> :define do
       } }
       it { should contain_cron('job1-backup').with(:command => '/usr/local/bin/backup perform --trigger job1 --config-file \'/etc/backup/config.rb\' --tmp-path /tmp') }
     end #set tmp-path
+
+    context 'set gem bin path' do
+      let(:params) { {
+        :types          => 'archive',
+        :add            => '/here',
+        :storage_type   => 'local',
+        :path           => '/backups',
+        :gem_bin_path   => '/usr/local/rvm/gems/ruby-2.2.1/bin'
+      } }
+      it { should contain_cron('job1-backup').with(:command => '/usr/local/rvm/gems/ruby-2.2.1/bin/backup perform --trigger job1 --config-file \'/etc/backup/config.rb\' --tmp-path ~/Backup/.tmp') }
+    end #set gem bin path
   end # cron entry
 
 end


### PR DESCRIPTION
`/usr/local/bin/` works if installed using system ruby, with other
ruby installations like _rvm_ or installation to user profile, the
path might not match.

The change is backwards compatible, the job manifest sets the current
one as default.
