### PR TITLE
Storage S3 support for use_iam_profile

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,7 @@ class backup (
   # S3
   $aws_access_key       = $::backup::params::aws_access_key,
   $aws_secret_key       = $::backup::params::aws_secret_key,
+  $use_iam_profile      = $::backup::params::use_iam_profile,
   $bucket               = $::backup::params::bucket,
   $aws_region           = $::backup::params::aws_region,
   # Remote storage common

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -47,6 +47,7 @@ define backup::job (
   # S3
   $aws_access_key      = $::backup::aws_access_key,
   $aws_secret_key      = $::backup::aws_secret_key,
+  $use_iam_profile     = $::backup::use_iam_profile,
   $bucket              = $::backup::bucket,
   $aws_region          = $::backup::aws_region,
   $reduced_redundancy  = $::backup::reduced_redundancy,
@@ -195,13 +196,16 @@ define backup::job (
   # S3
   if $storage_type == 's3' {
     validate_bool($reduced_redundancy)
+    validate_bool($use_iam_profile)
+    
+    if !$use_iam_profile {
+      if !$aws_access_key or !is_string($aws_access_key) {
+        fail("[Backup::Job::${name}]: Parameter aws_access_key is required for S3 storage")
+      }
 
-    if !$aws_access_key or !is_string($aws_access_key) {
-      fail("[Backup::Job::${name}]: Parameter aws_access_key is required for S3 storage")
-    }
-
-    if !$aws_secret_key or !is_string($aws_secret_key) {
-      fail("[Backup::Job::${name}]: Parameter aws_secret_key is required for S3 storage")
+      if !$aws_secret_key or !is_string($aws_secret_key) {
+        fail("[Backup::Job::${name}]: Parameter aws_secret_key is required for S3 storage")
+      }
     }
 
     if !$bucket or !is_string($bucket) {

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -460,6 +460,7 @@ define backup::job (
     # Template uses
     # - $aws_access_key
     # - $aws_secret_key
+    # - $use_iam_profile
     # - $path
     # - $aws_region
     # - $bucket

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,7 +43,7 @@ class backup::params {
   # S3
   $aws_access_key       = undef
   $aws_secret_key       = undef
-  $use_iam_profile      = undef
+  $use_iam_profile      = false
   $bucket               = undef
   $aws_region           = undef
   $reduced_redundancy   = false

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,6 +43,7 @@ class backup::params {
   # S3
   $aws_access_key       = undef
   $aws_secret_key       = undef
+  $use_iam_profile      = undef
   $bucket               = undef
   $aws_region           = undef
   $reduced_redundancy   = false

--- a/templates/job/s3.erb
+++ b/templates/job/s3.erb
@@ -2,8 +2,12 @@
   # Amazon Simple Storage Service [Storage]
   #
   store_with S3 do |s3|
+<% if @use_iam_profile -%>
+    s3.use_iam_profile   = "<%= @use_iam_profile -%>"
+<% else -%>
     s3.access_key_id     = "<%= @aws_access_key -%>"
     s3.secret_access_key = "<%= @aws_secret_key -%>"
+<% end -%>
     s3.path              = "<%= @_path -%>"
     s3.bucket            = "<%= @bucket -%>"
 <% if @aws_region -%>

--- a/templates/job/s3.erb
+++ b/templates/job/s3.erb
@@ -3,7 +3,7 @@
   #
   store_with S3 do |s3|
 <% if @use_iam_profile -%>
-    s3.use_iam_profile   = "<%= @use_iam_profile -%>"
+    s3.use_iam_profile   = true
 <% else -%>
     s3.access_key_id     = "<%= @aws_access_key -%>"
     s3.secret_access_key = "<%= @aws_secret_key -%>"

--- a/templates/job/s3.erb
+++ b/templates/job/s3.erb
@@ -18,5 +18,5 @@
 <% end -%>
 <% if @reduced_redundancy -%>
     s3.storage_class     = :reduced_redundancy
-<% end -%>
+<% end %>
   end


### PR DESCRIPTION
Storage S3 supports either the usage of access_key_id/secret_access_key to access AWS S3 or IAM Profiles if running inside the AWS infrastructure on EC2. Which is important, since one doesn't usually pass around Key IDs or Secret Keys when on EC2.
