### PR TITLE
Add support for rsync storage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,10 @@ sudo: false
 matrix:
   fast_finish: true
   include:
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3.3.0"
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
   - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.3.0"
+    env: PUPPET_GEM_VERSION="~> 3.8.0" JSON_PURE_GEM_VERSION="~> 1.8.3"
   - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
+    env: PUPPET_GEM_VERSION="~> 3.0" JSON_PURE_GEM_VERSION="~> 1.8.3" FUTURE_PARSER="yes"
   - rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 3.3.0"
   - rvm: 2.0.0
@@ -25,13 +21,3 @@ matrix:
     env: PUPPET_GEM_VERSION="~> 4.1"
   - rvm: 2.1.0
     env: PUPPET_GEM_VERSION="~> 4.2"
-notifications:
-  email: false
-  hipchat:
-    rooms:
-      - secure: CK11caPkzorkB4onwQPDolAFM32RO+Mn/rt3MRBe0xkt+SyRj8Icmv4MLbWUhiIydZQLrZpC+k993U9RuNOgghOcBq9tKF3U1sM6rrWLNJOnvobi6S+WZYe325IcsMchREERd0TUJYeYWCw2YxYlJBS/xRmpXO5gLZAPzm1NI9k=
-    template:
-      - '%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message} (<a href="%{build_url}">Details</a>/<a href="%{compare_url}">Change view</a>)'
-    format: html
-  on_success: always
-  on_failure: always

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,11 @@ group :unit_tests do
   gem 'puppet-syntax',                                              :require => false
   gem 'metadata-json-lint',                                         :require => false
   gem 'json',                                                       :require => false
+  if jasonpureversion = ENV['JSON_PURE_GEM_VERSION']
+    gem 'json_pure', jasonpureversion,                              :require => false
+  else
+    gem 'json_pure',                                                :require => false
+  end
   gem 'puppet-lint-absolute_classname-check',                       :require => false
   gem 'puppet-lint-appends-check',                                  :require => false
   gem 'puppet-lint-empty_string-check',                             :require => false

--- a/README.md
+++ b/README.md
@@ -276,6 +276,22 @@ String.  Bucket to store archive when using S3 storage type
 
 String.  Region to store archive when using S3 storage type
 
+##### `rsync_mode`
+
+String.  rsync mode to use with rsync storage
+
+##### `rsync_port`
+
+Integer.  Port for rsync storage model to use
+
+Default: 22
+
+##### `rsync_compress`
+
+Boolean.  Weather or not to enable rsync compression on transfer
+
+Default: undef (false)
+
 ##### `encryptor`
 
 String.  Encryptor to use on backup archive

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,12 @@ class backup (
   $rsync_mode           = $::backup::params::rsync_mode,
   $rsync_password_file  = $::backup::params::rsync_password_file,
 
+  ## Syncers
+  # Common
+  $syncer_type          = $::backup::params::syncer_type,
+  # Rsync
+  $syncer_rsync_type    = $::backup::params::syncer_rsync_type,
+
   ## Encryptors
   $encryptor            = $::backup::params::encryptor,
   # OpenSSL

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,9 @@ class backup (
   # FTP
   $ftp_port             = $::backup::params::ftp_port,
   $ftp_passive_mode     = $::backup::params::ftp_passive_mode,
+  # Rsync
+  $rsync_mode           = $::backup::params::rsync_mode,
+  $rsync_password_file  = $::backup::params::rsync_password_file,
 
   ## Encryptors
   $encryptor            = $::backup::params::encryptor,

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -62,6 +62,7 @@ define backup::job (
   $rsync_mode        = $::backup::rsync_mode,
   $rsync_port        = $::backup::rsync_port,
   $rsync_compress    = $::backup::rsync_compress,
+  $rsync_password_file = $::backup::rsync_password_file,
 
   ## Encryptors
   $encryptor         = $::backup::encryptor,
@@ -258,12 +259,15 @@ define backup::job (
     if !$storage_host or !is_string($storage_host) {
       fail("[Backup::Job::${name}]: Parameter storage_host is required for rsync storage")
     }
-    if !$rsync_port or !is_integer($rsync_port) {
+    if $rsync_port and !is_integer($rsync_port) {
       fail("[Backup::Job::${name}]: rsync_port must be an integer.  (Got: ${rsync_port})")
     }
 
     if $rsync_compress {
       validate_bool($rsync_compress)
+    }
+    if $rsync_password_file {
+      validate_string($rsync_password_file)
     }
 
   }

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -58,6 +58,10 @@ define backup::job (
   # FTP
   $ftp_port          = $::backup::ftp_port,
   $ftp_passive_mode  = $::backup::ftp_passive_mode,
+  # rsync
+  $rsync_mode        = $::backup::rsync_mode,
+  $rsync_port        = $::backup::rsync_port,
+  $rsync_compress    = $::backup::rsync_compress,
 
   ## Encryptors
   $encryptor         = $::backup::encryptor,
@@ -173,8 +177,8 @@ define backup::job (
   }
 
   # Storage
-  if !member(['s3', 'local', 'ftp'], $storage_type) {
-    fail("[Backup::Job::${name}]: Currently supported storage types are: ftp, local, and s3")
+  if !member(['s3', 'local', 'ftp', 'rsync'], $storage_type) {
+    fail("[Backup::Job::${name}]: Currently supported storage types are: ftp, local, s3, and rsync")
   }
 
   if $keep and !is_integer($keep) {
@@ -186,7 +190,7 @@ define backup::job (
   }
 
   # local and ftp require path parameter
-  if member(['ftp', 'local'], $storage_type) {
+  if member(['ftp', 'local', 'rsync'], $storage_type) {
     if !$path {
       fail("[Backup::Job::${name}]: Path parameter is required with storage_type => ${storage_type}")
     }
@@ -241,6 +245,27 @@ define backup::job (
     }
 
     validate_bool($ftp_passive_mode)
+  }
+
+  if $storage_type == 'rsync' {
+    if $rsync_mode and !member([
+        'ssh',
+        'ssh_daemon',
+        'rsync_daemon',
+      ], $rsync_mode ) {
+        fail("[Backup::Job::${name}]: ${rsync_mode} is not a valid mode")
+      }
+    if !$storage_host or !is_string($storage_host) {
+      fail("[Backup::Job::${name}]: Parameter storage_host is required for rsync storage")
+    }
+    if !$rsync_port or !is_integer($rsync_port) {
+      fail("[Backup::Job::${name}]: rsync_port must be an integer.  (Got: ${rsync_port})")
+    }
+
+    if $rsync_compress {
+      validate_bool($rsync_compress)
+    }
+
   }
 
   # Encryptor
@@ -477,6 +502,19 @@ define backup::job (
     concat::fragment { "${_name}_ftp":
       target  => "/etc/backup/models/${_name}.rb",
       content => template('backup/job/ftp.erb'),
+      order   => '35',
+    }
+  } elsif $storage_type == 'rsync' {
+    # Template uses
+    # - $server_username
+    # - $server_ip
+    # - $server_port
+    # - $server_compress
+    # - $server_mode
+    # - $path
+    concat::fragment { "${_name}_rsync":
+      target  => "/etc/backup/models/${_name}.rb",
+      content => template('backup/job/rsync.erb'),
       order   => '35',
     }
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -59,6 +59,12 @@ class backup::params {
   $rsync_compress       = undef
   $rsync_password_file  = undef
 
+  ## Syncers
+  # Common
+  $syncer_type          = undef
+  # Rsync options
+  $syncer_rsync_type    = 'RSync::Push'
+
   ## Encryptors
   $encryptor            = undef
   # OpenSSL

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -55,8 +55,9 @@ class backup::params {
   $ftp_passive_mode     = false
   # rsync
   $rsync_mode           = undef
-  $rsync_port           = 22
+  $rsync_port           = undef
   $rsync_compress       = undef
+  $rsync_password_file  = undef
 
   ## Encryptors
   $encryptor            = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -53,6 +53,10 @@ class backup::params {
   # FTP
   $ftp_port             = 21
   $ftp_passive_mode     = false
+  # rsync
+  $rsync_mode           = undef
+  $rsync_port           = 22
+  $rsync_compress       = undef
 
   ## Encryptors
   $encryptor            = undef

--- a/spec/defines/backup_job_spec.rb
+++ b/spec/defines/backup_job_spec.rb
@@ -1086,7 +1086,7 @@ describe 'backup::job', :types=> :define do
           :path             => '/there',
         } }
         it { should_not contain_concat__fragment('job1_rsync').with(:content => /server\..+user/) }
-        it { should contain_concat__fragment('job1_rsync').with(:content => /server\.ip\s+=\s"mysite.example.com"/) }
+        it { should contain_concat__fragment('job1_rsync').with(:content => /server\.host\s+=\s"mysite.example.com"/) }
         it { should contain_concat__fragment('job1_rsync').with(:content => /server\.port\s+=\s22$/) }
         it { should contain_concat__fragment('job1_rsync').with(:content => /server\.path\s+=\s"\/there"/) }
         it { should_not contain_concat__fragment('job1_rsync').with(:content => /server\.rsync_compress/) }

--- a/spec/defines/backup_job_spec.rb
+++ b/spec/defines/backup_job_spec.rb
@@ -346,7 +346,7 @@ describe 'backup::job', :types=> :define do
       end
     end # ftp
 
-    context 'rsync' do
+    context 'rsync storage' do
       context 'bad mode' do
         let(:params) { {
           :types            => 'archive',
@@ -436,6 +436,90 @@ describe 'backup::job', :types=> :define do
       end
 
     end # rsync
+
+    context 'syncer' do
+      context 'used with local storage only' do
+        let(:params) { {
+          :types               => ['syncer'],
+          :add                 => 'here',
+          :storage_type        => 'rsync',
+          :storage_username    => 'myuser',
+          :storage_host        => 'mysite.example.com',
+          :path                => '/there',
+        } }
+        it { expect { is_expected.to compile }.to raise_error(/When using syncers with storage you should only use local storage/)}
+      end
+
+      context 'dont use archive when no storage_type is used' do
+        let(:params) { {
+          :types               => ['archive', 'syncer'],
+          :add                 => 'here',
+          :path                => '/there',
+        } }
+        it { expect { is_expected.to compile }.to raise_error(/do not use archive when no storage_type is used/)}
+      end
+
+      context 'rsync' do
+        context 'storage_host paramater must be set' do
+          let(:params) { {
+            :types               => ['syncer'],
+            :add                 => 'here',
+            :syncer_type         => 'rsync',
+            :storage_username => 'bob',
+            :path                => '/there',
+          } }
+          it { expect { is_expected.to compile }.to raise_error(/Parameter storage_host is required for rsync/)}
+        end
+        context 'storage_username paramater must be set' do
+          let(:params) { {
+            :types        => ['syncer'],
+            :add          => 'here',
+            :syncer_type  => 'rsync',
+            :rsync_mode   => 'rsync_daemon',
+            :storage_host => 'mysite.example.com',
+            :path         => '/there',
+          } }
+          it { expect { is_expected.to compile }.to raise_error(/Parameter storage_username is required/)}
+        end
+        context 'incorrect rsync_mode' do
+          let(:params) { {
+            :types            => ['syncer'],
+            :add              => '/here',
+            :syncer_type      => 'rsync',
+            :rsync_mode       => ':rsync_daemon',
+            :storage_host     => 'mysite.example.com',
+            :storage_username => 'bob',
+            :path             => '/there'
+          } }
+          it { expect { is_expected.to compile }.to raise_error(/rsync_daemon is not a valid mode/)}
+        end
+        context 'missing add' do
+          let(:params) { {
+            :types            => ['syncer'],
+            :syncer_type      => 'rsync',
+            :rsync_mode       => 'rsync_daemon',
+            :storage_host     => 'mysite.example.com',
+            :storage_username => 'bob',
+            :path             => '/there'
+          } }
+          it { expect { is_expected.to compile }.to raise_error(/ Files or directories to archive need to be specified with the 'add' parameter/)}
+        end
+        context 'archive type with bad add' do
+          let(:params) { {
+            :types          => 'syncer',
+            :add            => { 'a' => 'b'},
+            :syncer_type      => 'rsync',
+            :rsync_mode       => 'rsync_daemon',
+            :storage_host     => 'mysite.example.com',
+            :storage_username => 'bob',
+            :path           => '/backups'
+          } }
+          it { expect { is_expected.to compile }.to raise_error(/add parameter takes either an individual path as a string or an array of paths/) }
+        end
+
+
+      end
+    end # Syncer
 
     context 'encryptor generic' do
       context 'bad encryptor' do

--- a/spec/defines/backup_job_spec.rb
+++ b/spec/defines/backup_job_spec.rb
@@ -406,6 +406,35 @@ describe 'backup::job', :types=> :define do
         } }
         it { expect { is_expected.to compile }.to raise_error(/"bob" is not a boolean/)}
       end
+
+      context 'bad rsync_compress' do
+        let(:params) { {
+          :types            => 'archive',
+          :add              => 'here',
+          :storage_type     => 'rsync',
+          :storage_username => 'myuser',
+          :storage_host     => 'mysite.example.com',
+          :path             => '/there',
+          :rsync_compress   => 'bob',
+        } }
+        it { expect { is_expected.to compile }.to raise_error(/"bob" is not a boolean/)}
+      end
+
+      context 'rsync_password_file is not a string' do
+        let(:params) { {
+          :types               => 'archive',
+          :add                 => 'here',
+          :storage_type        => 'rsync',
+          :storage_username    => 'myuser',
+          :storage_host        => 'mysite.example.com',
+          :path                => '/there',
+          :rsync_compress      => true,
+          :rsync_mode          => 'rsync_daemon',
+          :rsync_password_file => true
+        } }
+        it { expect { is_expected.to compile }.to raise_error(/true is not a string/)}
+      end
+
     end # rsync
 
     context 'encryptor generic' do
@@ -1087,7 +1116,6 @@ describe 'backup::job', :types=> :define do
         } }
         it { should_not contain_concat__fragment('job1_rsync').with(:content => /server\..+user/) }
         it { should contain_concat__fragment('job1_rsync').with(:content => /server\.host\s+=\s"mysite.example.com"/) }
-        it { should contain_concat__fragment('job1_rsync').with(:content => /server\.port\s+=\s22$/) }
         it { should contain_concat__fragment('job1_rsync').with(:content => /server\.path\s+=\s"\/there"/) }
         it { should_not contain_concat__fragment('job1_rsync').with(:content => /server\.rsync_compress/) }
       end
@@ -1107,6 +1135,21 @@ describe 'backup::job', :types=> :define do
         it { should contain_concat__fragment('job1_rsync').with(:content => /server\..+user\s+=\s"myuser"/) }
         it { should contain_concat__fragment('job1_rsync').with(:content => /server\.port\s+=\s22/) }
         it { should contain_concat__fragment('job1_rsync').with(:content => /server\.mode\s+=\s:ssh/) }
+      end
+
+      context 'rsync_daemon mode' do
+        let(:params) { {
+          :types            => 'archive',
+          :add              => '/here',
+          :storage_type     => 'rsync',
+          :storage_host     => 'mysite.example.com',
+          :path             => 'there',
+          :rsync_port       => 873,
+          :rsync_mode       => 'rsync_daemon',
+          :keep             => 10,
+        } }
+        it { should contain_concat__fragment('job1_rsync').with(:content => /server\.port\s+=\s873/) }
+        it { should contain_concat__fragment('job1_rsync').with(:content => /server\.mode\s+=\s:rsync_daemon/) }
       end
     end # rsync
 

--- a/templates/job/rsync.erb
+++ b/templates/job/rsync.erb
@@ -1,0 +1,21 @@
+  ##
+  # rsync [Storage]
+  #
+  store_with RSync do |server|
+<%if @storage_username and (@rsync_mode == 'ssh') -%>
+    server.ssh_user      = "<%= @storage_username -%>"
+<% elsif @storage_username -%>
+    server.rsync_user    = "<%= @storage_username -%>"
+<% end -%>
+    server.host          = "<%= @storage_host -%>"
+<%if @rsync_port -%>
+    server.port          = <%= @rsync_port %>
+<% end -%>
+    server.path          = "<%= @_path -%>"
+<% if @rsync_compress -%>
+    server.compress      = "<%= @rsync_compress %>"
+<% end -%>
+<% if @rsync_mode -%>
+    server.mode          = :<%= @rsync_mode %>
+<% end -%>
+  end

--- a/templates/job/rsync.erb
+++ b/templates/job/rsync.erb
@@ -18,4 +18,7 @@
 <% if @rsync_mode -%>
     server.mode          = :<%= @rsync_mode %>
 <% end -%>
+<% if @rsync_password_file -%>
+    server.rsync_password_file = "<%= @rsync_password_file %>"
+<% end -%>
   end

--- a/templates/job/rsync_syncer.erb
+++ b/templates/job/rsync_syncer.erb
@@ -1,0 +1,29 @@
+  ##
+  # rsync [Storage]
+  #
+  sync_with <%= @syncer_rsync_type %> do |rsync|
+<%if @storage_username and (@rsync_mode == 'ssh') -%>
+    rsync.ssh_user      = "<%= @storage_username -%>"
+<% elsif @storage_username -%>
+    rsync.rsync_user    = "<%= @storage_username -%>"
+<% end -%>
+    rsync.host          = "<%= @storage_host -%>"
+<%if @rsync_port -%>
+    rsync.port          = <%= @rsync_port %>
+<% end -%>
+    rsync.path          = "<%= @_path.sub(/(^\/)/, '\2') -%>"
+<% if @rsync_compress -%>
+    rsync.compress      = "<%= @rsync_compress %>"
+<% end -%>
+<% if @rsync_mode -%>
+    rsync.mode          = :<%= @rsync_mode %>
+<% end -%>
+<% if @rsync_password_file -%>
+    rsync.rsync_password_file = "<%= @rsync_password_file %>"
+<% end -%>
+    rsync.directories do |directory|
+<%  Array(@add).each do |element| -%>
+      directory.add '<%= element -%>'
+<% end -%>
+    end
+  end


### PR DESCRIPTION
Adds support for rsync storage and fixed some CI issues I ran into. I have removed Travis checks for older ruby 1.8.7 as it is EOL. Everything I added should have a corresponding test. 
